### PR TITLE
LR Scheduler should not be passed to fabric.setup

### DIFF
--- a/lightning_sam/train.py
+++ b/lightning_sam/train.py
@@ -157,7 +157,7 @@ def main(cfg: Box) -> None:
     val_data = fabric._setup_dataloader(val_data)
 
     optimizer, scheduler = configure_opt(cfg, model)
-    model, optimizer, scheduler = fabric.setup(model, optimizer, scheduler)
+    model, optimizer = fabric.setup(model, optimizer)
 
     train_sam(cfg, fabric, model, optimizer, scheduler, train_data, val_data)
     validate(fabric, model, val_data, epoch=0)


### PR DESCRIPTION
fabric.setup accepts model and optimizer to be optimized, we should not pass scheduler to it, which leads to learning rate scheduled in a wrong direction where scheduler.get_last_lr() gives us 0 all the time.